### PR TITLE
chore: add .prettierignore

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,9 @@
+node_modules
+dist
+build
+.next
+coverage
+*.min.js
+*.min.css
+package-lock.json
+yarn.lock


### PR DESCRIPTION
Adds .prettierignore to skip formatting for build artifacts and dependencies.